### PR TITLE
Change pgsql user id

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -16,7 +16,7 @@ service inetd start
 
 #dsystems is looking for user/group pgsql
 pw groupadd -q -n pgsql
-echo -n 'pgsql' | pw useradd -n pgsql -u 770 -s /bin/sh -m -d /usr/local/pgsql -g pgsql -G wheel -c 'Database User' -H 0
+echo -n 'pgsql' | pw useradd -n pgsql -u 769 -s /bin/sh -m -d /usr/local/pgsql -g pgsql -G wheel -c 'Database User' -H 0
 
 # Start the service
 service postgresql initdb

--- a/post_install.sh
+++ b/post_install.sh
@@ -16,7 +16,7 @@ service inetd start
 
 #dsystems is looking for user/group pgsql
 pw groupadd -q -n pgsql
-echo -n 'pgsql' | pw useradd -n pgsql -u 1001 -s /bin/sh -m -d /usr/local/pgsql -g pgsql -G wheel -c 'Database User' -H 0
+echo -n 'pgsql' | pw useradd -n pgsql -u 770 -s /bin/sh -m -d /usr/local/pgsql -g pgsql -G wheel -c 'Database User' -H 0
 
 # Start the service
 service postgresql initdb

--- a/post_install.sh
+++ b/post_install.sh
@@ -15,7 +15,7 @@ rm -f /etc/rc.d/inetd.bak
 service inetd start
 
 #dsystems is looking for user/group pgsql
-pw groupadd -q -n pgsql
+pw groupadd -q -n pgsql -g 769
 echo -n 'pgsql' | pw useradd -n pgsql -u 769 -s /bin/sh -m -d /usr/local/pgsql -g pgsql -G wheel -c 'Database User' -H 0
 
 # Start the service

--- a/pre_update.sh
+++ b/pre_update.sh
@@ -5,7 +5,7 @@ if [ "${pgsql_id}" != "769" ]; then
 	echo "Changing uid/gid of user/group pgsql"
 	pw groupmod -n pgsql -g 769
 	pw usermod -n pgsql -u 769 -g pgsql
-	find / -uid "${pgsql_id}" -exec chown -R pgsql:pgsql {} +
+	find -x /usr/local/pgsql -uid "${pgsql_id}" -exec chown -R pgsql:pgsql {} +
 fi
 
 echo "Starting postgresql service"

--- a/pre_update.sh
+++ b/pre_update.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+pgsql_id="$(id -u pgsql)"
+if [ "${pgsql_id}" != "769" ]; then
+	echo "Changing uid/gid of user/group pgsql"
+	pw groupmod -n pgsql -g 769
+	pw usermod -n pgsql -u 769 -g pgsql
+	find / -uid "${pgsql_id}" -exec chown -R pgsql:pgsql {} +
+fi
+
 echo "Starting postgresql service"
 service postgresql start
 


### PR DESCRIPTION
This PR introduces changes so that we use `uid/gid` of `769` for `pgsql` instead of `1001` as we leave uids above 1000 open for users.